### PR TITLE
various cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Installation
 Example Usage for Bittrex API
 
 ```python
-from bittrex import Bittrex
+from bittrex.bittrex import Bittrex, API_V2_0
 
 my_bittrex = Bittrex(None, None, api_version=API_V2_0)  # or defaulting to v1.1 as Bittrex(None, None)
 my_bittrex.get_markets()
@@ -34,7 +34,7 @@ Make sure you save the secret, as it will not be visible
 after navigating away from the page. 
 
 ```python
-from bittrex import Bittrex
+from bittrex.bittrex import *
 
 my_bittrex = Bittrex("<my_api_key>", "<my_api_secret>", api_version="<API_V1_1> or <API_V2_0>")
 

--- a/bittrex/__init__.py
+++ b/bittrex/__init__.py
@@ -1,1 +1,1 @@
-from .bittrex import *
+from .bittrex import *          # noqa

--- a/bittrex/bittrex.py
+++ b/bittrex/bittrex.py
@@ -8,10 +8,8 @@ import hashlib
 
 try:
     from urllib import urlencode
-    from urlparse import urljoin
 except ImportError:
     from urllib.parse import urlencode
-    from urllib.parse import urljoin
 
 try:
     from Crypto.Cipher import AES
@@ -154,7 +152,7 @@ class Bittrex(object):
 
             return self.dispatch(request_url, apisign)
 
-        except:
+        except Exception:
             return {
                 'success': False,
                 'message': 'NO_API_RESPONSE',
@@ -167,7 +165,7 @@ class Bittrex(object):
         at Bittrex along with other meta data.
 
         1.1 Endpoint: /public/getmarkets
-        2.0 Endpoint: /pub/Markets/GetMarkets
+        2.0 NO Equivalent
 
         Example ::
             {'success': True,
@@ -192,7 +190,6 @@ class Bittrex(object):
         """
         return self._api_query(path_dict={
             API_V1_1: '/public/getmarkets',
-            API_V2_0: '/pub/Markets/GetMarkets'
         }, protection=PROTECTION_PUB)
 
     def get_currencies(self):
@@ -295,7 +292,7 @@ class Bittrex(object):
 
         Endpoint:
         1.1 /market/getmarkethistory
-        2.0 /pub/Market/GetMarketHistory
+        2.0 NO Equivalent
 
         Example ::
             {'success': True,
@@ -318,7 +315,6 @@ class Bittrex(object):
         """
         return self._api_query(path_dict={
             API_V1_1: '/public/getmarkethistory',
-            API_V2_0: '/pub/Market/GetMarketHistory'
         }, options={'market': market, 'marketname': market}, protection=PROTECTION_PUB)
 
     def buy_limit(self, market, quantity, rate):
@@ -514,7 +510,7 @@ class Bittrex(object):
 
         Endpoint:
         1.1 /account/getorderhistory
-        2.0 /key/orders/getorderhistory
+        2.0 /key/orders/getorderhistory or /key/market/GetOrderHistory
 
         :param market: optional a string literal for the market (ie. BTC-LTC).
             If omitted, will return for all markets
@@ -522,10 +518,16 @@ class Bittrex(object):
         :return: order history in JSON
         :rtype : dict
         """
-        return self._api_query(path_dict={
-            API_V1_1: '/account/getorderhistory',
-            API_V2_0: '/key/orders/getorderhistory'
-        }, options={'market': market, 'marketname': market} if market else None, protection=PROTECTION_PRV)
+        if market:
+            return self._api_query(path_dict={
+                API_V1_1: '/account/getorderhistory',
+                API_V2_0: '/key/market/GetOrderHistory'
+            }, options={'market': market, 'marketname': market}, protection=PROTECTION_PRV)
+        else:
+            return self._api_query(path_dict={
+                API_V1_1: '/account/getorderhistory',
+                API_V2_0: '/key/orders/getorderhistory'
+            }, protection=PROTECTION_PRV)
 
     def get_order(self, uuid):
         """

--- a/bittrex/test/bittrex_tests.py
+++ b/bittrex/test/bittrex_tests.py
@@ -1,9 +1,12 @@
 import unittest
 import json
-import os
 from bittrex.bittrex import Bittrex, API_V2_0, API_V1_1, BUY_ORDERBOOK, TICKINTERVAL_ONEMIN
 
-IS_CI_ENV = True if 'IN_CI' in os.environ else False
+try:
+    open("secrets.json").close()
+    IS_CI_ENV = False
+except Exception:
+    IS_CI_ENV = True
 
 
 def test_basic_response(unit_test, result, method_name):
@@ -83,7 +86,7 @@ class TestBittrexV11PublicAPI(unittest.TestCase):
 
     def test_get_latest_candle(self):
         self.assertRaisesRegexp(Exception, 'method call not available', self.bittrex.get_latest_candle, market='BTC-LTC',
-                               tick_interval=TICKINTERVAL_ONEMIN)
+                                tick_interval=TICKINTERVAL_ONEMIN)
 
 
 class TestBittrexV20PublicAPI(unittest.TestCase):
@@ -98,22 +101,16 @@ class TestBittrexV20PublicAPI(unittest.TestCase):
     def test_handles_none_key_or_secret(self):
         self.bittrex = Bittrex(None, None, api_version=API_V2_0)
         # could call any public method here
-        actual = self.bittrex.get_markets()
+        actual = self.bittrex.get_market_summaries()
         self.assertTrue(actual['success'], "failed with None key and None secret")
 
         self.bittrex = Bittrex("123", None, api_version=API_V2_0)
-        actual = self.bittrex.get_markets()
+        actual = self.bittrex.get_market_summaries()
         self.assertTrue(actual['success'], "failed with None secret")
 
         self.bittrex = Bittrex(None, "123", api_version=API_V2_0)
-        actual = self.bittrex.get_markets()
+        actual = self.bittrex.get_market_summaries()
         self.assertTrue(actual['success'], "failed with None key")
-
-    def test_get_markets(self):
-        actual = self.bittrex.get_markets()
-        test_basic_response(self, actual, "get_markets")
-        self.assertTrue(isinstance(actual['result'], list), "result is not a list")
-        self.assertTrue(len(actual['result']) > 0, "result list is 0-length")
 
     def test_get_currencies(self):
         actual = self.bittrex.get_currencies()
@@ -134,14 +131,6 @@ class TestBittrexV20PublicAPI(unittest.TestCase):
     def test_get_orderbook(self):
         actual = self.bittrex.get_orderbook('BTC-LTC')
         test_basic_response(self, actual, "get_orderbook")
-
-    def test_get_market_history(self):
-        actual = self.bittrex.get_market_history('BTC-LTC')
-        test_basic_response(self, actual, "get_market_history")
-
-    def test_list_markets_by_currency(self):
-        actual = self.bittrex.list_markets_by_currency('LTC')
-        self.assertListEqual(['BTC-LTC', 'ETH-LTC', 'USDT-LTC'], actual)
 
     def test_get_wallet_health(self):
         actual = self.bittrex.get_wallet_health()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(name='python-bittrex',
       version='0.2.1',
-      url = "https://github.com/ericsomdahl/python-bittrex",
+      url="https://github.com/ericsomdahl/python-bittrex",
       packages=['bittrex'],
       modules=['bittrex'],
       install_requires=['requests'],


### PR DESCRIPTION
- fix README to show correct import statements
- fixed flake8 reports
- removed get_markets and get_market_history that seems not available anymore in V2_0
- use /key/orders/getorderhistory to get order history by market in V2_0
- tests: tweak IS_CI_ENV to only rely on secrets.json being present