### PR TITLE
Add support for optional paymentid's when withdrawing

### DIFF
--- a/bittrex/bittrex.py
+++ b/bittrex/bittrex.py
@@ -482,7 +482,7 @@ class Bittrex(object):
             API_V2_0: '/key/balance/getdepositaddress'
         }, options={'currency': currency, 'currencyname': currency}, protection=PROTECTION_PRV)
 
-    def withdraw(self, currency, quantity, address):
+    def withdraw(self, currency, quantity, address, paymentid=None):
         """
         Used to withdraw funds from your account
 
@@ -496,13 +496,16 @@ class Bittrex(object):
         :type quantity: float
         :param address: The address where to send the funds.
         :type address: str
+        :param paymentid: Optional argument for memos, tags, or other supplemental information for cryptos such as XRP.
+        :type paymentid: str
         :return:
         :rtype : dict
         """
         return self._api_query(path_dict={
             API_V1_1: '/account/withdraw',
             API_V2_0: '/key/balance/withdrawcurrency'
-        }, options={'currency': currency, 'quantity': quantity, 'address': address}, protection=PROTECTION_PRV)
+        }, options={'currency': currency, 'quantity': quantity, 'address': address, 'paymentid': paymentid}
+            if paymentid else None, protection=PROTECTION_PRV)
 
     def get_order_history(self, market=None):
         """


### PR DESCRIPTION
It seems the current Python Wrapper does not include a way to add the optional paymentid for withdrawing payments. 

I think it is also worth noting that if you tried to withdraw cryptos that requires tags / memo's / paymentids that the Bittrex official REST API would return as a success, but would error on the web client. (Hopefully someone from Bittrex may see this?) 

Fully tested using my own funds. 😄 