### PR TITLE
Fixed withdraw method

### DIFF
--- a/bittrex/bittrex.py
+++ b/bittrex/bittrex.py
@@ -504,11 +504,17 @@ class Bittrex(object):
         :return:
         :rtype : dict
         """
+        options = {
+            'currency': currency,
+            'quantity': quantity,
+            'address': address
+        }
+        if paymentid:
+            options['paymentid'] = paymentid
         return self._api_query(path_dict={
             API_V1_1: '/account/withdraw',
             API_V2_0: '/key/balance/withdrawcurrency'
-        }, options={'currency': currency, 'quantity': quantity, 'address': address, 'paymentid': paymentid}
-            if paymentid else None, protection=PROTECTION_PRV)
+        }, options=options, protection=PROTECTION_PRV)
 
     def get_order_history(self, market=None):
         """


### PR DESCRIPTION
If paymentid was None (optional) request wasn't sending any data because of invalid check